### PR TITLE
remove retry command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 jdk: openjdk11
 language: java
-bundler_args: --retry 2
 git:
   quiet: true
 


### PR DESCRIPTION
Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.
